### PR TITLE
Include "types" in @twind/macro installations

### DIFF
--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -14,7 +14,8 @@
   "types": "types/index.d.ts",
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "author": {
     "name": "MapleLeaf",


### PR DESCRIPTION
Currently this directory is not included, thus the `tw` prop isn't recognized:

![image](https://user-images.githubusercontent.com/22670878/128644965-26291682-0b14-4398-a868-8ad537fb3105.png)

![image](https://user-images.githubusercontent.com/22670878/128644973-560d11a1-2ad7-4fee-897f-ca4670583116.png)

Hopefully including the "types" directory in the package "files" resolves this.